### PR TITLE
Add configurable laser/bucket counts to bucket workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,5 +41,13 @@
     -   `train.py`: Adam + L-BFGS 최적화 루프를 처리하는 `Trainer` 클래스를 구현합니다.
 -   `examples/`: 라이브러리 사용법을 보여주는 스크립트가 포함되어 있습니다.
     -   `solve_helmholtz_1d.py`: 1D 헬름홀츠 방정식을 푸는 완전한 예제. 데이터 생성부터 훈련, 시각화까지 포함합니다.
+    -   `generate_bucket_data.py`: 버킷 강도 이미지와 위상 지도를 생성하는 유틸리티.
+    -   `train_bucket_pinn.py`: 생성된 버킷 데이터를 사용하여 Scaled-cPIKAN PINN을 학습합니다.
+    -   `infer_bucket_pinn.py`: 학습된 모델을 로드하여 높이 지도를 추론합니다.
+    -   `bucket` 기반 워크플로우를 위한 예제 스크립트가 아래 절에 설명되어 있습니다.
 -   `tests/`: 코드의 정확성을 보장하기 위한 단위 및 통합 테스트입니다.
 -   `helmholtz_*.png`: 예제 스크립트에 의해 생성된 출력 이미지 예시입니다.
+
+### 버킷 기반 3D 복원 워크플로우
+
+`generate_bucket_data.py`는 기본적으로 4개의 레이저와 각 레이저당 3개의 버킷 영상을 생성하여 총 12장의 이미지를 구성합니다. `--num-lasers`, `--num-buckets`, `--wavelengths` 인자를 통해 레이저와 버킷 수를 자유롭게 조절할 수 있습니다. 데이터 생성 후에는 `train_bucket_pinn.py`로 모델을 학습하고, `infer_bucket_pinn.py`로 높이 지도를 복원할 수 있습니다.

--- a/examples/generate_bucket_data.py
+++ b/examples/generate_bucket_data.py
@@ -1,0 +1,37 @@
+import argparse
+import numpy as np
+from reconstruction.data_generator import generate_synthetic_data, DEFAULT_WAVELENGTHS
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Generate synthetic bucket data for reconstruction experiments.")
+    parser.add_argument("--shape", type=int, nargs=2, default=[128, 128], metavar=("H", "W"),
+                        help="Height and width of generated images (default: 128 128)")
+    parser.add_argument("--output", type=str, default="reconstruction_data",
+                        help="Directory to save generated numpy arrays (default: reconstruction_data)")
+    parser.add_argument("--num-lasers", type=int, default=4,
+                        help="Number of lasers to simulate (default: 4)")
+    parser.add_argument("--num-buckets", type=int, default=3,
+                        help="Number of phase-shifted bucket images per laser (default: 3)")
+    parser.add_argument("--wavelengths", type=float, nargs='+', default=None,
+                        help="Custom wavelengths for lasers in micrometers; overrides --num-lasers")
+    args = parser.parse_args()
+
+    if args.wavelengths is not None:
+        wavelengths = args.wavelengths
+    else:
+        if args.num_lasers <= len(DEFAULT_WAVELENGTHS):
+            wavelengths = DEFAULT_WAVELENGTHS[:args.num_lasers]
+        else:
+            wavelengths = np.linspace(DEFAULT_WAVELENGTHS[0], DEFAULT_WAVELENGTHS[-1], args.num_lasers).tolist()
+
+    generate_synthetic_data(
+        shape=tuple(args.shape),
+        wavelengths=wavelengths,
+        num_buckets=args.num_buckets,
+        save_path=args.output,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/infer_bucket_pinn.py
+++ b/examples/infer_bucket_pinn.py
@@ -1,0 +1,47 @@
+import argparse
+import os
+
+import numpy as np
+import torch
+
+from src.models import Scaled_cPIKAN
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Run inference with a trained Scaled-cPIKAN model on bucket data.")
+    parser.add_argument("--data-dir", type=str, default="reconstruction_data",
+                        help="Directory containing bucket_images.npy")
+    parser.add_argument("--model-path", type=str, default="bucket_model.pth",
+                        help="Path to trained model weights")
+    parser.add_argument("--output", type=str, default="reconstructed_height.npy",
+                        help="File to save reconstructed height map")
+    args = parser.parse_args()
+
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+    bucket_images = np.load(os.path.join(args.data_dir, "bucket_images.npy"))
+    H, W = bucket_images.shape[2:]
+
+    x = torch.linspace(0, 1, H, device=device)
+    y = torch.linspace(0, 1, W, device=device)
+    grid_x, grid_y = torch.meshgrid(x, y, indexing="ij")
+    coords = torch.stack([grid_x.flatten(), grid_y.flatten()], dim=1)
+
+    domain_min = torch.tensor([0.0, 0.0], device=device)
+    domain_max = torch.tensor([1.0, 1.0], device=device)
+    model = Scaled_cPIKAN(layers_dims=[2, 64, 64, 64, 1],
+                          cheby_order=8,
+                          domain_min=domain_min,
+                          domain_max=domain_max).to(device)
+    model.load_state_dict(torch.load(args.model_path, map_location=device))
+    model.eval()
+
+    with torch.no_grad():
+        pred_height = model(coords).view(H, W).cpu().numpy()
+
+    np.save(args.output, pred_height)
+    print(f"Saved reconstructed height to {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/train_bucket_pinn.py
+++ b/examples/train_bucket_pinn.py
@@ -1,0 +1,106 @@
+import argparse
+import os
+from collections import defaultdict
+
+import numpy as np
+import torch
+
+from src.models import Scaled_cPIKAN
+
+
+class ReconstructionLossFromBuckets(torch.nn.Module):
+    """Loss computing bucket intensity consistency and smoothness."""
+    def __init__(self, wavelengths, num_buckets, smoothness_weight=1e-7):
+        super().__init__()
+        self.wavelengths = torch.tensor(wavelengths, dtype=torch.float32).view(-1, 1, 1, 1)
+        deltas = torch.arange(num_buckets, dtype=torch.float32) * (2 * np.pi / num_buckets)
+        self.deltas = deltas.view(1, num_buckets, 1, 1)
+        self.smoothness_weight = smoothness_weight
+        self.mse_loss = torch.nn.MSELoss()
+        self.metrics = {}
+
+    def forward(self, predicted_height, coords, targets):
+        self.wavelengths = self.wavelengths.to(predicted_height.device)
+        self.deltas = self.deltas.to(predicted_height.device)
+
+        predicted_phase = (4 * np.pi / self.wavelengths) * predicted_height
+        phase_with_shifts = predicted_phase.unsqueeze(1) + self.deltas
+        A, B = 128, 100
+        predicted_buckets = A + B * torch.cos(phase_with_shifts)
+        loss_data = self.mse_loss(predicted_buckets, targets)
+
+        h = predicted_height.squeeze(0).squeeze(0)
+        grad_h = torch.autograd.grad(h.sum(), coords, create_graph=True)[0]
+        h_x, h_y = grad_h[:, 0], grad_h[:, 1]
+        h_xx = torch.autograd.grad(h_x.sum(), coords, create_graph=True)[0][:, 0]
+        h_yy = torch.autograd.grad(h_y.sum(), coords, create_graph=True)[0][:, 1]
+        laplacian = h_xx + h_yy
+        loss_smoothness = self.mse_loss(laplacian, torch.zeros_like(laplacian))
+
+        total_loss = loss_data + self.smoothness_weight * loss_smoothness
+        self.metrics = {
+            "loss_total": total_loss.item(),
+            "loss_data": loss_data.item(),
+            "loss_smoothness": loss_smoothness.item(),
+        }
+        return total_loss
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Train Scaled-cPIKAN using bucket images.")
+    parser.add_argument("--data-dir", type=str, default="reconstruction_data",
+                        help="Directory containing bucket_images.npy and ground_truth_height.npy")
+    parser.add_argument("--model-path", type=str, default="bucket_model.pth",
+                        help="Path to save trained model weights")
+    parser.add_argument("--epochs", type=int, default=1000,
+                        help="Number of Adam epochs (default: 1000)")
+    parser.add_argument("--lr", type=float, default=1e-3,
+                        help="Learning rate for Adam (default: 1e-3)")
+    args = parser.parse_args()
+
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+    bucket_images = np.load(os.path.join(args.data_dir, "bucket_images.npy"))
+    wavelengths = np.load(os.path.join(args.data_dir, "wavelengths.npy"))
+    num_lasers, num_buckets, H, W = bucket_images.shape
+    bucket_images_t = torch.from_numpy(bucket_images).float().to(device).view(num_lasers, num_buckets, -1)
+
+    x = torch.linspace(0, 1, H, device=device)
+    y = torch.linspace(0, 1, W, device=device)
+    grid_x, grid_y = torch.meshgrid(x, y, indexing="ij")
+    coords = torch.stack([grid_x.flatten(), grid_y.flatten()], dim=1)
+    coords.requires_grad_(True)
+
+    domain_min = torch.tensor([0.0, 0.0], device=device)
+    domain_max = torch.tensor([1.0, 1.0], device=device)
+    model = Scaled_cPIKAN(layers_dims=[2, 64, 64, 64, 1],
+                          cheby_order=8,
+                          domain_min=domain_min,
+                          domain_max=domain_max).to(device)
+
+    loss_fn = ReconstructionLossFromBuckets(wavelengths, num_buckets)
+    optimizer = torch.optim.Adam(model.parameters(), lr=args.lr)
+    history = defaultdict(list)
+
+    for epoch in range(args.epochs):
+        model.train()
+        optimizer.zero_grad()
+        predicted_height = model(coords).view(1, 1, -1)
+        loss = loss_fn(predicted_height, coords, bucket_images_t)
+        loss.backward()
+        optimizer.step()
+
+        for k, v in loss_fn.metrics.items():
+            history[k].append(v)
+        if (epoch + 1) % max(1, args.epochs // 10) == 0:
+            log_str = f"Epoch [{epoch+1}/{args.epochs}]"
+            for k, v in loss_fn.metrics.items():
+                log_str += f" - {k}: {v:.4e}"
+            print(log_str)
+
+    torch.save(model.state_dict(), args.model_path)
+    print(f"Saved model weights to {args.model_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/reconstruction/data_generator.py
+++ b/reconstruction/data_generator.py
@@ -2,33 +2,50 @@ import numpy as np
 import os
 
 # --- Configuration ---
-# Wavelengths for the 4 lasers (in micrometers, for example)
-# Chosen to be non-integer multiples to aid in unwrapping.
-# Renamed from WAVELENGTHS to Wavelengths to match import in the PINN script.
-Wavelengths = [5.0, 5.5, 6.05, 6.655]
+# Default wavelengths for four lasers (in micrometers, for example).
+# Users can supply their own list to change the number of lasers.
+DEFAULT_WAVELENGTHS = [5.0, 5.5, 6.05, 6.655]
 
-def generate_synthetic_data(shape=(128, 128), save_path="reconstruction_data"):
+# Backward compatibility alias
+Wavelengths = DEFAULT_WAVELENGTHS
+
+
+def generate_synthetic_data(
+    shape=(128, 128),
+    wavelengths=None,
+    num_buckets=3,
+    save_path="reconstruction_data",
+):
     """
     Generates and optionally saves all synthetic data for the 3D reconstruction problem.
 
-    This function creates a ground truth height map and then simulates the
-    3-bucket measurement process for each of the 4 lasers to produce
-    both the raw bucket images and the final wrapped phase maps.
+    This function creates a ground truth height map and then simulates a
+    phase-shifting bucket measurement process for each laser wavelength to
+    produce both the raw bucket images and the final wrapped phase maps.
 
     Args:
         shape (tuple[int, int]): The (height, width) of the data grids to generate.
-        save_path (str | None): The directory to save the generated .npy files.
-                                If None, data is not saved to disk.
+        wavelengths (list[float] | None): Wavelength for each laser. If None,
+            ``DEFAULT_WAVELENGTHS`` is used.
+        num_buckets (int): Number of phase-shifted bucket images per laser.
+        save_path (str | None): Directory to save generated ``.npy`` files. If
+            ``None`` data is not saved to disk.
 
     Returns:
         tuple[np.ndarray, list[np.ndarray], np.ndarray]: A tuple containing:
             - ground_truth_height (np.ndarray): The 2D ground truth height map.
-            - wrapped_phases (list[np.ndarray]): A list of 4 wrapped phase maps.
-            - bucket_images (np.ndarray): An array of shape (4, 3, H, W) containing
-                                          the 3 bucket images for each of the 4 lasers.
+            - wrapped_phases (list[np.ndarray]): A list of ``len(wavelengths)`` wrapped
+              phase maps.
+            - bucket_images (np.ndarray): An array of shape
+              ``(len(wavelengths), num_buckets, H, W)`` containing the bucket
+              images for each laser.
     """
     print("--- Starting Synthetic Data Generation ---")
     height, width = shape
+
+    if wavelengths is None:
+        wavelengths = DEFAULT_WAVELENGTHS
+    num_lasers = len(wavelengths)
 
     # --- Ground Truth Height Map Generation ---
     x = np.linspace(-1, 1, width)
@@ -43,60 +60,51 @@ def generate_synthetic_data(shape=(128, 128), save_path="reconstruction_data"):
     # --- Simulation of Phase-Shift Imaging for each laser ---
     all_bucket_images = []
     wrapped_phases = []
-    for i, wavelength in enumerate(Wavelengths):
-        # Phase is proportional to height and inversely proportional to wavelength
+    deltas = np.linspace(0, 2 * np.pi, num_buckets, endpoint=False)
+
+    for i, wavelength in enumerate(wavelengths):
         phase = (4 * np.pi * ground_truth_height) / wavelength
 
-        # Simulate intensity images with some background illumination (A) and modulation (B)
         A = 128
         B = 100
-        # Phase shifts for the 3 buckets
-        delta_0 = 0
-        delta_1 = 2 * np.pi / 3
-        delta_2 = 4 * np.pi / 3
-        I0 = A + B * np.cos(phase + delta_0)
-        I1 = A + B * np.cos(phase + delta_1)
-        I2 = A + B * np.cos(phase + delta_2)
 
-        # Store the bucket images for this laser
-        laser_buckets = np.stack([I0, I1, I2], axis=0)
+        buckets = [A + B * np.cos(phase + delta) for delta in deltas]
+        laser_buckets = np.stack(buckets, axis=0)
         all_bucket_images.append(laser_buckets)
 
-        # Calculate wrapped phase from the three bucket images
-        numerator = np.sqrt(3) * (I2 - I1)
-        denominator = 2 * I0 - I1 - I2
-        wrapped_phase = np.arctan2(numerator, denominator)
+        sum_sin = np.sum(laser_buckets * np.sin(deltas)[:, None, None], axis=0)
+        sum_cos = np.sum(laser_buckets * np.cos(deltas)[:, None, None], axis=0)
+        wrapped_phase = np.arctan2(-sum_sin, sum_cos)
         wrapped_phases.append(wrapped_phase)
-        print(f"Generated bucket images and wrapped phase for Laser {i+1} (Wavelength: {wavelength} um)...")
+        print(
+            f"Generated {num_buckets} bucket images and wrapped phase for Laser {i+1} (Wavelength: {wavelength} um)..."
+        )
 
-    # Convert list of bucket images to a single numpy array
-    bucket_images_np = np.stack(all_bucket_images, axis=0) # Shape: (4, 3, H, W)
+    bucket_images_np = np.stack(all_bucket_images, axis=0)  # Shape: (num_lasers, num_buckets, H, W)
 
-    # --- Save data if a path is provided ---
     if save_path:
         os.makedirs(save_path, exist_ok=True)
         print(f"\nSaving data to directory: {save_path}")
-        # Save ground truth
         gt_path = os.path.join(save_path, "ground_truth_height.npy")
         np.save(gt_path, ground_truth_height)
         print(f"Saved ground truth height to {gt_path}")
 
-        # Save phase maps
         for i, wrapped_phase in enumerate(wrapped_phases):
             phase_path = os.path.join(save_path, f"wrapped_phase_laser_{i+1}.npy")
             np.save(phase_path, wrapped_phase)
             print(f"Saved wrapped phase for laser {i+1} to {phase_path}")
 
-        # Save bucket images
         buckets_path = os.path.join(save_path, "bucket_images.npy")
         np.save(buckets_path, bucket_images_np)
         print(f"Saved all bucket images to {buckets_path}")
 
+        wl_path = os.path.join(save_path, "wavelengths.npy")
+        np.save(wl_path, np.asarray(wavelengths, dtype=np.float32))
+        print(f"Saved wavelengths to {wl_path}")
 
     print("\n--- Synthetic Data Generation Complete ---")
     return ground_truth_height, wrapped_phases, bucket_images_np
 
 
 if __name__ == "__main__":
-    # To maintain the original behavior of running this file as a script
     generate_synthetic_data(shape=(512, 512), save_path="reconstruction_data")


### PR DESCRIPTION
## Summary
- allow synthetic data generation for an arbitrary number of lasers and bucket images
- expose CLI options to customize laser wavelengths and bucket/laser counts
- train PINN models from datasets with variable shapes by loading wavelengths from disk
- document bucket-based 3D reconstruction workflow

## Testing
- `pytest -q` *(fails: No module named pytest)*

------
https://chatgpt.com/codex/tasks/task_e_68aad69969c083218f1ac5e272064b63