### PR TITLE
Generalize bucket target reshape

### DIFF
--- a/examples/solve_reconstruction_from_buckets.py
+++ b/examples/solve_reconstruction_from_buckets.py
@@ -158,8 +158,10 @@ def main():
     coords.requires_grad_(True)
 
     # Reshape targets (bucket images) to match flattened coordinates
-    # Shape: [4, 3, H, W] -> [4, 3, H*W]
-    targets = bucket_images_t.view(4, 3, -1)
+    # Shape: [num_lasers, num_buckets, H, W] -> [num_lasers, num_buckets, H*W]
+    num_lasers = bucket_images_t.shape[0]
+    num_buckets = bucket_images_t.shape[1]
+    targets = bucket_images_t.view(num_lasers, num_buckets, -1)
 
     # Instantiate the loss function
     loss_fn = ReconstructionLossFromBuckets(


### PR DESCRIPTION
## Summary
- Make bucket target reshape dynamic using num_lasers and num_buckets

## Testing
- `pytest -q`
- `python examples/solve_reconstruction_from_buckets.py` *(timed run to verify execution)*
- `python - <<'PY' ...` *(verify flexible laser/bucket counts)*

------
https://chatgpt.com/codex/tasks/task_e_68aaddcc994883218a23ebc371170d42