### PR TITLE
Fix device mismatch in bucket reconstruction example

### DIFF
--- a/examples/solve_reconstruction_from_buckets.py
+++ b/examples/solve_reconstruction_from_buckets.py
@@ -203,7 +203,7 @@ def main():
     loss_fn = ReconstructionLossFromBuckets(
         wavelengths=args.wavelengths,
         smoothness_weight=1e-7,  # NOTE: This weight may need significant tuning
-    )
+    ).to(device)
 
     # --- Adam Optimization ---
     adam_epochs = 10000


### PR DESCRIPTION
## Summary
- ensure reconstruction loss module runs on the same device as model outputs

## Testing
- `python examples/solve_reconstruction_from_buckets.py --num-lasers 4 --num-buckets 3 --wavelengths 5.0 5.5 6.05 6.655` *(fails: KeyboardInterrupt after verifying start of training)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aaf24e57a48321a10d5286c8d70847